### PR TITLE
fix setuptools issue resulting in Makefile install error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import sys
 
-from Cython.Build import cythonize
 from setuptools import setup, find_packages
+from Cython.Build import cythonize
 
 if sys.version_info < (3, 6):
     raise Exception('Must be using Python 3.6 or above.')


### PR DESCRIPTION
Hi, got this error on last kali release so I shouldn't be the only one having it, quick search result in an old setuptools bug with simple workaround:

https://stackoverflow.com/questions/21594925/error-each-element-of-ext-modules-option-must-be-an-extension-instance-or-2-t